### PR TITLE
redundant dependencies: sip and python-sip

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros-noetic-qt-gui-cpp
 	pkgdesc = ROS - qt_gui_cpp provides the foundation for C++-bindings for qt_gui and creates bindings for every generator available.
 	pkgver = 0.4.2
-	pkgrel = 2
+	pkgrel = 3
 	url = https://wiki.ros.org/qt_gui_cpp
 	arch = i686
 	arch = x86_64
@@ -22,8 +22,6 @@ pkgbase = ros-noetic-qt-gui-cpp
 	depends = ros-noetic-pluginlib
 	depends = ros-noetic-qt-gui
 	depends = tinyxml
-	depends = sip
-	depends = python-sip
 	depends = sip4
 	depends = python-sip4
 	source = ros-noetic-qt-gui-cpp-0.4.2.tar.gz::https://github.com/ros-visualization/qt_gui_core/archive/0.4.2.tar.gz

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@ url='https://wiki.ros.org/qt_gui_cpp'
 pkgname='ros-noetic-qt-gui-cpp'
 pkgver='0.4.2'
 arch=('i686' 'x86_64' 'aarch64' 'armv7h' 'armv6h')
-pkgrel=2
+pkgrel=3
 license=('BSD')
 
 ros_makedepends=(
@@ -32,8 +32,6 @@ ros_depends=(
 depends=(
     ${ros_depends[@]}
     tinyxml
-    sip
-    python-sip
     sip4
     python-sip4
 )


### PR DESCRIPTION
`ros-noetic` uses `sip4` and `python-sip4` only.